### PR TITLE
Adjusted cell-splitting regex to ignore pipe symbols between pairs of backticks

### DIFF
--- a/src/format-table.ts
+++ b/src/format-table.ts
@@ -15,7 +15,7 @@ function padding(len: number, str: string = ' ') {
 }
 const stripTailPipes = (str: string) => str.trim().replace(/(^\||\|$)/g, '');
 const splitCells = (str: string) => {
-    return str.split(/\|(?!`)/);
+    return str.match(/((?:[^`|]|(?:`[^`]*`)|(?:`[^`]*$))+)/g) || []
 };
 const addTailPipes = (str: string) => `|${str}|`;
 const joinCells = (arr: string[]) => arr.join('|');


### PR DESCRIPTION
Fixes #4.

Probably good idea to have a good test of this because while I've had a go I don't know much about the edge cases involved.